### PR TITLE
Bug fixes in image preprocessing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
+
+### Preprocessing
+
+#### BACH
+https://iciar2018-challenge.grand-challenge.org/Dataset/
+- Microscopy images, NOT WSIs. Whole-slide images are high resolution images containing the entire sampled tissue. In this sense, microscopy images are just details of the whole-slide images.
+
+#### BRACS
+https://www.bracs.icar.cnr.it/details/
+- The Regions of Interest are provided in .png file format. The filename of a RoI includes the filename of the corresponding WSI as well as the subtype of RoI (e.g. BRACS_010_PB_32.png is the RoI number 32, extracted from the WSI named BRACS_010.svs and labeled as Pathological Benign). The resolution of each RoI is 40× and its dimension can easily exceed 4,000 by 4,000 pixels.
+
+#### MIDOG
+https://imig.science/midog2021/download-dataset/
+- cropped regions of interest from 200 individual tumor cases
+- The assignment of the scanners to the files is as follows:
+    001.tiff to 050.tiff: Hamamatsu XR
+    051.tiff to 100.tiff: Hamamatsu S360 (with 0.5 numerical aperture)
+    101.tiff to 150.tiff: Aperio ScanScope CS2
+    151.tiff to 200.tiff: Leica GT450 (only images, no annotations provided for this scanner)
+
 [![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-22041afd0340ce965d47ae6ef1cefeee28c7c493a6346c4f15d667ab976d596c.svg)](https://classroom.github.com/a/UDdkOEMs)

--- a/preprocessing/generate_metadata.py
+++ b/preprocessing/generate_metadata.py
@@ -5,19 +5,18 @@ import os
 
 
 if __name__ == "__main__":
-    dataset = "BRACS_RoI"
+    dataset = "MIDOG"
 
-    if dataset == "BRACS_RoI":
-        images_dir = f"/capstor/scratch/cscs/vsubrama/data/{dataset}/images/"
-        list_of_images = sorted(glob(f"{images_dir}/*"))
-        print(len(list_of_images))
+    images_dir = f"/home/carlos/ml-project-2-ml-ts-4science/dev_data/{dataset}/images/"
+    list_of_images = sorted(glob(f"{images_dir}/*"))
+    print(len(list_of_images))
 
-        list_of_basenames = [os.path.basename(image_name) for image_name in list_of_images]
-        # list_of_classes = [os.path.basename(image_name).split("-")[0] for image_name in list_of_images]
+    list_of_basenames = [os.path.basename(image_name) for image_name in list_of_images]
+    # list_of_classes = [os.path.basename(image_name).split("-")[0] for image_name in list_of_images]
 
-        data_df = pd.DataFrame({"Image Name": list_of_basenames, 
-                                # "Tissue Class": list_of_classes
-                                })
-        print(data_df)
+    data_df = pd.DataFrame({"Image Name": list_of_basenames, 
+                            # "Tissue Class": list_of_classes
+                            })
+    print(data_df)
 
-        data_df.to_csv(f"/capstor/scratch/cscs/vsubrama/data/{dataset}/images_metadata.csv")
+    data_df.to_csv(f"/home/carlos/ml-project-2-ml-ts-4science/dev_data/{dataset}/images_metadata.csv")

--- a/preprocessing/utils/ImageTileExtractor/extract_tissue_from_images.py
+++ b/preprocessing/utils/ImageTileExtractor/extract_tissue_from_images.py
@@ -13,7 +13,7 @@ MAX_PIXEL_DIFFERENCE = 0.2 # difference must be within 20% of image size
 
 base_mpps_dict = {"BACH": 0.42,
                   "BRACS": 0.25, #in microns per pixel (MPP)
-                  "BRACS_RoI": 0.25 #in microns per pixel (MPP)
+                  "MIDOG": 0.25, #TODO: check this value for the images from the scanners. We know which scanner was used for each image
                  }
 
 def image_base_mpp(dataset):
@@ -183,7 +183,7 @@ def addoverlap(w, grid, overlap, patch_size, mpp, maxmpp, img, offset=0):
         if connu[i]: extra.extend(zip(x+ox.flatten()-offset,y-oy.flatten()-offset))
     return extra
 
-def make_sample_grid(image, remove_white_areas_bool=False, patch_size=224, mpp=0.5, min_cc_size=10, max_ratio_size=10, dilate=False, erode=False, prune=False, overlap=1, maxn=None, bmp=None, oversample=False, mult=1, centerpixel=False, base_mpp=None):
+def make_sample_grid(image, patch_size=224, mpp=0.5, min_cc_size=10, max_ratio_size=10, dilate=False, erode=False, prune=False, overlap=1, maxn=None, bmp=None, oversample=False, mult=1, centerpixel=False, base_mpp=None, remove_white_areas_bool=False):
     '''
     Script that given an openslide object return a list of tuples
     in the form of (x,y) coordinates for patch extraction of sample patches.
@@ -196,7 +196,7 @@ def make_sample_grid(image, remove_white_areas_bool=False, patch_size=224, mpp=0
     if base_mpp is None:
         base_mpp = isyntax_mpp
     
-    if remove_white_areas_bool == True:
+    if remove_white_areas_bool:
         if oversample:
             img, th = threshold(image, patch_size, base_mpp, base_mpp, mult)
         else:


### PR DESCRIPTION
Fixed some issues in the image preprocessing pipeline. It now runs without errors for MIDOG, BACH, and BRACS.

- `extract_tissue_from_images.make_sample_grid`. We moved the optional parameter remove_white_areas_bool to the end of the method because it was added last and was causing issues with the make_sample_grid method calls. In base_mpps_dict we added the mapping for MIDOG and removed the mapping of BRICS_RoI, which is the same as BRICS.
- `preprocess`. We created a list of valid datasets so that we dont need to update all the lists of valid datasets every time we make a change. We added the remove_white_areas_bool argument to save_metadata_to_file. We fixed some bugs in the main function call for the image processing pipeline: created the tiles_metadata directory, run the pipeline even if some of the images where already processed (it was breaking bug), we replaced all instances of BRACS_RoI for BRACS.
- `generate_metadata`. We removed the if clause because it was not doing anything useful. 
- `README`. I will be using it as a way to share notes or relevant findings.