### PR TITLE
Fix openslide bug

### DIFF
--- a/UNI/infer_uni_regions.py
+++ b/UNI/infer_uni_regions.py
@@ -24,12 +24,13 @@ class TileDataset(Dataset):
         self.downsample = downsample
         self.coordinates = coordinates
         self.transform = transform
+        self.slide_path = slide_path
 
     def __len__(self):
         return len(self.coordinates)
 
     def __getitem__(self, idx: int) -> torch.Tensor:
-        with open_slide(slide_path) as slide:  # Must be initialized in each worker
+        with open_slide(self.slide_path) as slide:  # Must be initialized in each worker
             level = slide.get_best_level_for_downsample(self.downsample)
             lvl_f = slide.level_downsamples
             patch_size_src = round(


### PR DESCRIPTION
- infer_uni_regions.Tiledataset. We fixed a bug related to the openslide object instantiated in the dataset class.

### Tests
- Embedded `b001.tif`, the first image in BACH, at 20x
<img width="652" alt="Screenshot 2024-11-21 at 15 11 44" src="https://github.com/user-attachments/assets/56274191-ae1e-49c6-875d-b957cfc82c6e">
